### PR TITLE
Fix: Replace irongut/CodeCoverageSummary with ReportGenerator + Codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,25 +54,28 @@ jobs:
       if: github.ref == 'refs/heads/master'
       run: dotnet nuget push ${{github.workspace}}/src/bin/$BuildConfiguration/$SettingsOnADOId.Json.$PackageVersion.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_API_KEY }} --skip-duplicate
 
-    - name: Code Coverage Report
-      uses: irongut/CodeCoverageSummary@v1.3.0
-      continue-on-error: true
+    - name: Install ReportGenerator
+      run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+    - name: Merge and generate coverage report
+      run: |
+        reportgenerator \
+          -reports:"coverage/**/coverage.cobertura.xml" \
+          -targetdir:"coverage/report" \
+          -reporttypes:"MarkdownSummaryGithub;Cobertura" \
+          -assemblyfilters:"-*.Tests"
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
       with:
-        filename: coverage/**/coverage.cobertura.xml
-        badge: true
-        fail_below_min: false
-        format: markdown
-        hide_branch_rate: false
-        hide_complexity: true
-        indicators: true
-        output: both
-        thresholds: '40 60'
+        files: coverage/report/Cobertura.xml
+        fail_ci_if_error: false
 
     - name: Add Coverage PR Comment
       uses: marocchino/sticky-pull-request-comment@v2
       if: github.event_name == 'pull_request'
       with:
         recreate: true
-        path: code-coverage-results.md
+        path: coverage/report/SummaryGithub.md
 
 


### PR DESCRIPTION
## Problem
`irongut/CodeCoverageSummary@v1.3.0` is abandoned (last release 2022) and incorrectly aggregates coverage when multiple test projects produce separate `coverage.cobertura.xml` files. The reported totals are unreliable.

## Solution
- **ReportGenerator** correctly merges all Cobertura XML files from multiple test projects into a single canonical file before reporting. Produces a `MarkdownSummaryGithub` formatted report for the PR comment.
- **Codecov** provides a persistent web dashboard with line-by-line coverage, PR diff annotations, and trend graphs. Free for public repos — no token needed. The `fail_ci_if_error: false` flag ensures CI never fails if Codecov is temporarily unavailable.

## Changes
- Remove `irongut/CodeCoverageSummary@v1.3.0` (abandoned)
- Add `dotnet tool install dotnet-reportgenerator-globaltool`
- Add `reportgenerator` step that merges all coverage files and produces `MarkdownSummaryGithub` + merged `Cobertura.xml`
- Add `codecov/codecov-action@v4` uploading the merged Cobertura file
- Update PR comment step to use `coverage/report/SummaryGithub.md` instead of `code-coverage-results.md`