### PR TITLE
Add CODEOWNERS — @DaveRMaltby as global owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files — @DaveRMaltby is the global code owner
+* @DaveRMaltby


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` file making @DaveRMaltby the global code owner for all files in the repository

## Test plan
- [ ] Verify that @DaveRMaltby is automatically requested as a reviewer on future pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)