### PR TITLE
chore: upgrade all projects from .NET 8 to .NET 10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Set version number
       run:  '& ${{github.workspace}}/.github/workflows/UpdateVersion.ps1 ${{github.run_number}}'

--- a/src/SettingsOnADO.Json/SettingsOnADO.Json.csproj
+++ b/src/SettingsOnADO.Json/SettingsOnADO.Json.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
 	<LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/SettingsOnADO/SettingsOnADO.csproj
+++ b/src/SettingsOnADO/SettingsOnADO.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
 	<LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <PackageId>ServantSoftware.SettingsOnADO</PackageId>

--- a/tests/SettingsOnADO.Json.Tests/SettingsOnADO.Json.Tests.csproj
+++ b/tests/SettingsOnADO.Json.Tests/SettingsOnADO.Json.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/tests/SettingsOnADO.Tests/SettingsOnADO.Tests.csproj
+++ b/tests/SettingsOnADO.Tests/SettingsOnADO.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary
Upgrades all `net8.0` target frameworks to `net10.0` and updates the GitHub Actions workflow to install the .NET 10 SDK.

`netstandard*` projects are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)