### PR TITLE
chore: enforce TreatWarningsAsErrors and upgrade GitHub Actions (#4)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,7 @@ packages
 *.metaproj
 *.metaproj.tmp
 
-
+# Gas Town / Claude workspace
+.beads/
+.claude/
+.runtime/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,7 @@
     <DefaultArtifactsFileMatch>*.nupkg *.snupkg</DefaultArtifactsFileMatch>
     <DelaySign>false</DelaySign>
     <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CI)' == 'true'">


### PR DESCRIPTION
## Summary
- Add `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` to `Directory.Build.props` to enforce zero-warning builds
- Upgrade `actions/checkout` from v3 to v4
- Upgrade `actions/setup-dotnet` from v2 to v4

Closes #4

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — all 36 tests pass

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>