### PR TITLE
Add encryption provider tests

### DIFF
--- a/tests/SettingsOnADO.Tests/AesEncryptionProviderTests.cs
+++ b/tests/SettingsOnADO.Tests/AesEncryptionProviderTests.cs
@@ -1,0 +1,160 @@
+using System.Security.Cryptography;
+using Xunit;
+
+namespace SettingsOnADO.Tests;
+
+public class AesEncryptionProviderTests
+{
+    private static byte[] GenerateKey(int bits = 256)
+    {
+        var key = new byte[bits / 8];
+        RandomNumberGenerator.Fill(key);
+        return key;
+    }
+
+    [Fact]
+    public void EncryptDecrypt_RoundTrip_ReturnsOriginalPlaintext()
+    {
+        var provider = new AesEncryptionProvider(GenerateKey());
+        var plaintext = "Hello, World!";
+
+        var ciphertext = provider.Encrypt(plaintext);
+        var result = provider.Decrypt(ciphertext);
+
+        Assert.Equal(plaintext, result);
+    }
+
+    [Fact]
+    public void Encrypt_DifferentPlaintexts_ProduceDifferentCiphertexts()
+    {
+        var provider = new AesEncryptionProvider(GenerateKey());
+
+        var cipher1 = provider.Encrypt("plaintext1");
+        var cipher2 = provider.Encrypt("plaintext2");
+
+        Assert.NotEqual(cipher1, cipher2);
+    }
+
+    [Fact]
+    public void Encrypt_SamePlaintext_ProducesDifferentCiphertexts()
+    {
+        // Because a random IV is generated per call
+        var provider = new AesEncryptionProvider(GenerateKey());
+        var plaintext = "same text";
+
+        var cipher1 = provider.Encrypt(plaintext);
+        var cipher2 = provider.Encrypt(plaintext);
+
+        Assert.NotEqual(cipher1, cipher2);
+    }
+
+    [Fact]
+    public void EncryptDecrypt_EmptyString()
+    {
+        var provider = new AesEncryptionProvider(GenerateKey());
+
+        var ciphertext = provider.Encrypt(string.Empty);
+        var result = provider.Decrypt(ciphertext);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void EncryptDecrypt_UnicodeAndSpecialCharacters()
+    {
+        var provider = new AesEncryptionProvider(GenerateKey());
+        var plaintext = "Ünïcödé 日本語 🔑 <script>alert('xss')</script>";
+
+        var ciphertext = provider.Encrypt(plaintext);
+        var result = provider.Decrypt(ciphertext);
+
+        Assert.Equal(plaintext, result);
+    }
+
+    [Fact]
+    public void Decrypt_InvalidBase64_ThrowsFormatException()
+    {
+        var provider = new AesEncryptionProvider(GenerateKey());
+
+        Assert.Throws<FormatException>(() => provider.Decrypt("not-valid-base64!!!"));
+    }
+
+    [Fact]
+    public void Decrypt_CorruptedCiphertext_ThrowsCryptographicException()
+    {
+        var provider = new AesEncryptionProvider(GenerateKey());
+        var ciphertext = provider.Encrypt("test");
+
+        // Corrupt the ciphertext by modifying bytes after the IV
+        var bytes = Convert.FromBase64String(ciphertext);
+        bytes[bytes.Length - 1] ^= 0xFF;
+        var corrupted = Convert.ToBase64String(bytes);
+
+        Assert.ThrowsAny<CryptographicException>(() => provider.Decrypt(corrupted));
+    }
+
+    [Fact]
+    public void Constructor_InvalidKeySize_ThrowsCryptographicException()
+    {
+        var badKey = new byte[10]; // AES requires 16, 24, or 32 byte keys
+        var provider = new AesEncryptionProvider(badKey);
+
+        Assert.ThrowsAny<CryptographicException>(() => provider.Encrypt("test"));
+    }
+
+    [Theory]
+    [InlineData(128)]
+    [InlineData(192)]
+    [InlineData(256)]
+    public void EncryptDecrypt_ValidKeySizes(int keyBits)
+    {
+        var provider = new AesEncryptionProvider(GenerateKey(keyBits));
+        var plaintext = "test with different key sizes";
+
+        var ciphertext = provider.Encrypt(plaintext);
+        var result = provider.Decrypt(ciphertext);
+
+        Assert.Equal(plaintext, result);
+    }
+
+#pragma warning disable CS0618 // Suppress obsolete warning for testing the obsolete constructor
+    [Fact]
+    public void ObsoleteConstructor_IgnoresIvParameter_StillWorks()
+    {
+        var key = GenerateKey();
+        var iv = new byte[16];
+        RandomNumberGenerator.Fill(iv);
+
+        var provider = new AesEncryptionProvider(key, iv);
+        var plaintext = "test obsolete constructor";
+
+        var ciphertext = provider.Encrypt(plaintext);
+        var result = provider.Decrypt(ciphertext);
+
+        Assert.Equal(plaintext, result);
+    }
+#pragma warning restore CS0618
+
+    [Fact]
+    public void EncryptDecrypt_LongString()
+    {
+        var provider = new AesEncryptionProvider(GenerateKey());
+        var plaintext = new string('A', 10_000);
+
+        var ciphertext = provider.Encrypt(plaintext);
+        var result = provider.Decrypt(ciphertext);
+
+        Assert.Equal(plaintext, result);
+    }
+
+    [Fact]
+    public void Decrypt_WithWrongKey_ThrowsCryptographicException()
+    {
+        var provider1 = new AesEncryptionProvider(GenerateKey());
+        var provider2 = new AesEncryptionProvider(GenerateKey());
+
+        var ciphertext = provider1.Encrypt("secret");
+
+        Assert.ThrowsAny<CryptographicException>(() => provider2.Decrypt(ciphertext));
+    }
+}

--- a/tests/SettingsOnADO.Tests/DataProtectionEncryptionProviderTests.cs
+++ b/tests/SettingsOnADO.Tests/DataProtectionEncryptionProviderTests.cs
@@ -1,0 +1,130 @@
+using Microsoft.AspNetCore.DataProtection;
+using Moq;
+using Xunit;
+
+namespace SettingsOnADO.Tests;
+
+public class DataProtectionEncryptionProviderTests
+{
+    private static DataProtectionEncryptionProvider CreateProvider()
+    {
+        var dpProvider = new EphemeralDataProtectionProvider();
+        return new DataProtectionEncryptionProvider(dpProvider);
+    }
+
+    [Fact]
+    public void EncryptDecrypt_RoundTrip_ReturnsOriginalPlaintext()
+    {
+        var provider = CreateProvider();
+        var plaintext = "Hello, World!";
+
+        var ciphertext = provider.Encrypt(plaintext);
+        var result = provider.Decrypt(ciphertext);
+
+        Assert.Equal(plaintext, result);
+    }
+
+    [Fact]
+    public void Encrypt_ProducesDifferentOutputThanInput()
+    {
+        var provider = CreateProvider();
+        var plaintext = "sensitive data";
+
+        var ciphertext = provider.Encrypt(plaintext);
+
+        Assert.NotEqual(plaintext, ciphertext);
+    }
+
+    [Fact]
+    public void EncryptDecrypt_EmptyString()
+    {
+        var provider = CreateProvider();
+
+        var ciphertext = provider.Encrypt(string.Empty);
+        var result = provider.Decrypt(ciphertext);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void EncryptDecrypt_UnicodeAndSpecialCharacters()
+    {
+        var provider = CreateProvider();
+        var plaintext = "Ünïcödé 日本語 🔑 <script>alert('xss')</script>";
+
+        var ciphertext = provider.Encrypt(plaintext);
+        var result = provider.Decrypt(ciphertext);
+
+        Assert.Equal(plaintext, result);
+    }
+
+    [Fact]
+    public void Decrypt_InvalidCiphertext_Throws()
+    {
+        var provider = CreateProvider();
+
+        Assert.ThrowsAny<Exception>(() => provider.Decrypt("not-a-valid-protected-payload"));
+    }
+
+    [Fact]
+    public void Constructor_UsesCorrectPurpose()
+    {
+        // Verify that the provider creates a protector with the expected purpose string
+        var mockProtector = new Mock<IDataProtector>();
+        var mockProvider = new Mock<IDataProtectionProvider>();
+        mockProvider
+            .Setup(p => p.CreateProtector("SettingsOnADO.Encryption"))
+            .Returns(mockProtector.Object);
+
+        var provider = new DataProtectionEncryptionProvider(mockProvider.Object);
+
+        mockProvider.Verify(p => p.CreateProtector("SettingsOnADO.Encryption"), Times.Once);
+    }
+
+    [Fact]
+    public void Encrypt_DelegatesTo_Protect()
+    {
+        var mockProtector = new Mock<IDataProtector>();
+        mockProtector.Setup(p => p.Protect(It.IsAny<byte[]>()))
+            .Returns<byte[]>(input => input); // pass-through for the mock
+        var mockProvider = new Mock<IDataProtectionProvider>();
+        mockProvider
+            .Setup(p => p.CreateProtector(It.IsAny<string>()))
+            .Returns(mockProtector.Object);
+
+        var provider = new DataProtectionEncryptionProvider(mockProvider.Object);
+        provider.Encrypt("test");
+
+        // Verify Protect was called (the IDataProtector.Protect extension calls the byte[] overload)
+        mockProtector.Verify(p => p.Protect(It.IsAny<byte[]>()), Times.Once);
+    }
+
+    [Fact]
+    public void Decrypt_DelegatesTo_Unprotect()
+    {
+        var mockProtector = new Mock<IDataProtector>();
+        mockProtector.Setup(p => p.Unprotect(It.IsAny<byte[]>()))
+            .Returns<byte[]>(input => input); // pass-through for the mock
+        var mockProvider = new Mock<IDataProtectionProvider>();
+        mockProvider
+            .Setup(p => p.CreateProtector(It.IsAny<string>()))
+            .Returns(mockProtector.Object);
+
+        var provider = new DataProtectionEncryptionProvider(mockProvider.Object);
+        provider.Decrypt("dGVzdA=="); // base64 of "test"
+
+        mockProtector.Verify(p => p.Unprotect(It.IsAny<byte[]>()), Times.Once);
+    }
+
+    [Fact]
+    public void EncryptDecrypt_LongString()
+    {
+        var provider = CreateProvider();
+        var plaintext = new string('B', 10_000);
+
+        var ciphertext = provider.Encrypt(plaintext);
+        var result = provider.Decrypt(ciphertext);
+
+        Assert.Equal(plaintext, result);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AesEncryptionProviderTests` (14 tests): round-trip, empty string, unicode, invalid base64, corrupted ciphertext, wrong key, invalid key size, all valid key sizes (128/192/256), obsolete constructor, long string, same-plaintext-different-ciphertext
- Add `DataProtectionEncryptionProviderTests` (9 tests): round-trip, empty string, unicode, invalid ciphertext, correct purpose string verification, Protect/Unprotect delegation, long string

Closes #27

## Test plan
- [x] All 23 new tests pass
- [x] Full test suite (55 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>