### PR TITLE
feat: add Delete<T> API for settings entities

### DIFF
--- a/src/SettingsOnADO.Json/JsonSettingsManager.cs
+++ b/src/SettingsOnADO.Json/JsonSettingsManager.cs
@@ -53,4 +53,11 @@ public class JsonSettingsManager : SettingsManager
 
         base.Update(settings);
     }
+
+    public override void Delete<TSettingsEntity>()
+    {
+        jsonConnectionEx.settingsTypes.TryAdd(typeof(TSettingsEntity).Name, typeof(TSettingsEntity));
+
+        base.Delete<TSettingsEntity>();
+    }
 }

--- a/src/SettingsOnADO/ISettingsManager.cs
+++ b/src/SettingsOnADO/ISettingsManager.cs
@@ -8,4 +8,6 @@ public interface ISettingsManager : ISettingsPubSub, IDisposable
         where TSettingsEntity : class, new();
     void Update<TSettingsEntity>(TSettingsEntity settings)
         where TSettingsEntity : class, new();
+    void Delete<TSettingsEntity>()
+        where TSettingsEntity : class, new();
 }

--- a/src/SettingsOnADO/ISettingsRepository.cs
+++ b/src/SettingsOnADO/ISettingsRepository.cs
@@ -6,4 +6,6 @@ public interface ISettingsRepository
         where TSettingsEntity : class, new();
     void Update<TSettingsEntity>(TSettingsEntity settings)
         where TSettingsEntity : class, new();
+    void Delete<TSettingsEntity>()
+        where TSettingsEntity : class, new();
 }

--- a/src/SettingsOnADO/SettingsManager.cs
+++ b/src/SettingsOnADO/SettingsManager.cs
@@ -36,6 +36,13 @@ public class SettingsManager : ISettingsManager, ISettingsPubSub, IDisposable
         settingsPubSub.Notify(oldSettings, settings);
     }
 
+    public virtual void Delete<TSettingsEntity>() where TSettingsEntity : class, new()
+    {
+        var oldSettings = settingsRepository.Get<TSettingsEntity>();
+        settingsRepository.Delete<TSettingsEntity>();
+        settingsPubSub.Notify(oldSettings, new TSettingsEntity());
+    }
+
     public void Subscribe<TSettingsEntity>(Action<SettingsChangeEventArgs<TSettingsEntity>> handler) where TSettingsEntity : class, new() =>
         settingsPubSub.Subscribe(handler);
 

--- a/src/SettingsOnADO/SettingsManagerWithCache.cs
+++ b/src/SettingsOnADO/SettingsManagerWithCache.cs
@@ -40,6 +40,14 @@ public class SettingsManagerWithCache : ISettingsManagerWithCache, ISettingsMana
         return innerSettingsManager.Get<TSettingsEntity>();
     }
 
+    public void Delete<TSettingsEntity>() where TSettingsEntity : class, new()
+    {
+        var oldSettings = Get<TSettingsEntity>();
+        RemoveCacheValue<TSettingsEntity>();
+        innerSettingsManager.Delete<TSettingsEntity>();
+        settingsPubSub.Notify(oldSettings, new TSettingsEntity());
+    }
+
     public void Update<TSettingsEntity>(TSettingsEntity settings) where TSettingsEntity : class, new()
     {
         var oldSettings = Get<TSettingsEntity>();

--- a/src/SettingsOnADO/SettingsRepository.cs
+++ b/src/SettingsOnADO/SettingsRepository.cs
@@ -159,6 +159,12 @@ public class SettingsRepository : ISettingsRepository
         schemaManager.InsertTableData(tableName, insertColumns);
     }
 
+    public void Delete<TSettingsEntity>() where TSettingsEntity : class, new()
+    {
+        var tableName = GetTableName<TSettingsEntity>();
+        schemaManager.DeleteTableData(tableName);
+    }
+
     /// <summary>
     /// Gets the value of a property and encrypts it if the property is marked with the EncryptedAttribute and the encryption provider is available.
     /// </summary>

--- a/tests/SettingsOnADO.Tests/SettingsManagerTests.cs
+++ b/tests/SettingsOnADO.Tests/SettingsManagerTests.cs
@@ -67,6 +67,30 @@ public class SettingsManagerTests : IDisposable
     }
 
     [Fact]
+    public void Delete_ShouldCallRepositoryDeleteAndNotifySubscribers()
+    {
+        // Arrange
+        var oldSettings = new TestSettings { Id = 1, Name = "Old Name" };
+        _mockSettingsRepository.Setup(r => r.Get<TestSettings>()).Returns(oldSettings);
+
+        var subscriberCalled = false;
+        _settingsManager.Subscribe<TestSettings>(args =>
+        {
+            Assert.Equal(oldSettings, args.OldSettings);
+            Assert.Equal(0, args.NewSettings.Id);       // default value
+            Assert.Null(args.NewSettings.Name);          // default value
+            subscriberCalled = true;
+        });
+
+        // Act
+        _settingsManager.Delete<TestSettings>();
+
+        // Assert
+        Assert.True(subscriberCalled);
+        _mockSettingsRepository.Verify(r => r.Delete<TestSettings>(), Times.Once);
+    }
+
+    [Fact]
     public void Subscribe_ShouldCallSubscriberWhenUpdateIsCalled()
     {
         // Arrange

--- a/tests/SettingsOnADO.Tests/SettingsManagerWithCacheTests.cs
+++ b/tests/SettingsOnADO.Tests/SettingsManagerWithCacheTests.cs
@@ -151,6 +151,51 @@ public class SettingsManagerWithCacheTests
     }
 
     [Fact]
+    public void Delete_ShouldCallInnerManagerDeleteAndClearCache()
+    {
+        // Arrange
+        var testSettings = new TestSettings { Id = 1, Name = "Test Name" };
+        settingsManagerWithCache.SetCacheValue(testSettings);
+
+        mockSettingsManager.Invocations.Clear();
+
+        // Act
+        settingsManagerWithCache.Delete<TestSettings>();
+
+        // Assert
+        mockSettingsManager.Verify(m => m.Delete<TestSettings>(), Times.Once);
+
+        // Verify cache was cleared - Get should now fall through to inner manager
+        var fallbackSettings = new TestSettings { Id = 2, Name = "From Inner Manager" };
+        mockSettingsManager.Setup(m => m.Get<TestSettings>()).Returns(fallbackSettings);
+        var result = settingsManagerWithCache.Get<TestSettings>();
+        Assert.Equal(fallbackSettings.Id, result.Id);
+    }
+
+    [Fact]
+    public void Delete_ShouldNotifySubscribers()
+    {
+        // Arrange
+        var oldSettings = new TestSettings { Id = 1, Name = "Old Name" };
+        mockSettingsManager.Setup(m => m.Get<TestSettings>()).Returns(oldSettings);
+
+        var subscriberCalled = false;
+        settingsManagerWithCache.Subscribe<TestSettings>(args =>
+        {
+            Assert.Equal(oldSettings.Id, args.OldSettings.Id);
+            Assert.Equal(0, args.NewSettings.Id);       // default value
+            Assert.Null(args.NewSettings.Name);          // default value
+            subscriberCalled = true;
+        });
+
+        // Act
+        settingsManagerWithCache.Delete<TestSettings>();
+
+        // Assert
+        Assert.True(subscriberCalled);
+    }
+
+    [Fact]
     public void Dispose_ShouldDisposeInnerSettingsManager()
     {
         // Act

--- a/tests/SettingsOnADO.Tests/SettingsRepositoryTests.cs
+++ b/tests/SettingsOnADO.Tests/SettingsRepositoryTests.cs
@@ -117,6 +117,20 @@ public class SettingsRepositoryTests
     }
 
     [Fact]
+    public void Delete_ShouldCallDeleteTableDataOnSchemaManager()
+    {
+        // Arrange
+        var schemaManagerMock = new Mock<ISchemaManager>();
+        var repository = new SettingsRepository(schemaManagerMock.Object, null);
+
+        // Act
+        repository.Delete<TestSettings>();
+
+        // Assert
+        schemaManagerMock.Verify(m => m.DeleteTableData("TestSettings"), Times.Once);
+    }
+
+    [Fact]
     public void Update_EncryptsPropertiesWithEncryptedAttribute()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Adds `Delete<TSettingsEntity>()` method to `ISettingsManager` and `ISettingsRepository` interfaces
- Implements across the full stack: `SettingsRepository`, `SettingsManager`, `SettingsManagerWithCache`, and `JsonSettingsManager`
- Delete notifies pub/sub subscribers with old settings → default `new T()` and evicts cache entries in the cache-aware manager

## Test plan
- [x] `SettingsRepositoryTests.Delete_ShouldCallDeleteTableDataOnSchemaManager` — verifies repository delegates to `SchemaManager.DeleteTableData`
- [x] `SettingsManagerTests.Delete_ShouldCallRepositoryDeleteAndNotifySubscribers` — verifies manager calls repository and fires pub/sub
- [x] `SettingsManagerWithCacheTests.Delete_ShouldCallInnerManagerDeleteAndClearCache` — verifies cache eviction on delete
- [x] `SettingsManagerWithCacheTests.Delete_ShouldNotifySubscribers` — verifies cached manager fires pub/sub
- [x] All 68 existing + new tests pass

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)